### PR TITLE
Fit sigma with axisymmetric disk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,3 +27,7 @@
  - Added masking of edges of mocks to mitigate convolution edge effects
  - Renamed to NIRVANA
  - Removed MCMC and associated arguments
+ - Enable fit to velocity dispersion using `AxisymmetricDisk`.
+ - Force calculation of `mom0` in `nirvana.model.beam.smear` even if the
+   surface brightness is not provided, using a unity array.
+

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -258,7 +258,7 @@ class Kinematics(FitArgs):
                 setattr(self, attr, getattr(self, attr).ravel()[indx])
 
         # Calculate the square of the astrophysical velocity
-        # dispeersion. This is just the square of the velocity
+        # dispersion. This is just the square of the velocity
         # dispersion if no correction is provided. The error
         # calculation assumes there is no error on the correction.
         self.sig_phys2 = self.sig**2 if self.sig_corr is None else self.sig**2 - self.sig_corr**2

--- a/nirvana/fitting.py
+++ b/nirvana/fitting.py
@@ -327,21 +327,25 @@ def loglike(params, args):
 
     #add in sigma model if applicable
     if sigmodel is not None:
-        #use corrected physical dispersion if it is defined
-        if args.sig_phys2 is not None: 
-            sigdata = args.sig_phys2
-            if args.sig_phys2_ivar is not None:
-                sigdataivar = args.sig_phys2_ivar
-            else: sigdataivar = None
+#        #use corrected physical dispersion if it is defined
+#        if args.sig_phys2 is not None: 
+#            sigdata = args.sig_phys2
+#            if args.sig_phys2_ivar is not None:
+#                sigdataivar = args.sig_phys2_ivar
+#            else: sigdataivar = None
+#
+#        #otherwise use normal dispersion
+#        else:
+#            sigdata = args.sig**2
+#            if args.sig_ivar is not None:
+#                sigdataivar = args.sig_ivar**2
+#            else: sigdataivar = None
 
-        #otherwise use normal dispersion
-        else:
-            sigdata = args.sig**2
-            if args.sig_ivar is not None:
-                sigdataivar = args.sig_ivar**2
-            else: sigdataivar = None
+        sigdata = args.sig_phys2
+        sigdataivar = args.sig_phys2_ivar
 
         #compute chisq
+        # TODO: Shouldn't this be (sigmodel**2 - sigdata)**2?
         siglike = (sigmodel - sigdata)**2
         if sigdataivar is not None: siglike *= sigdataivar
         llike = llike - .5*np.ma.sum(siglike)

--- a/nirvana/models/beam.py
+++ b/nirvana/models/beam.py
@@ -322,7 +322,8 @@ def smear(v, beam, beam_fft=False, sb=None, sig=None, cnvfftw=None):
                                     if cnvfftw is None else cnvfftw.fft(beam, shift=True))
 
     # Get the first moment of the beam-smeared intensity distribution
-    mom0 = None if sb is None else _cnv(sb, bfft, kernel_fft=True)
+    mom0 = _cnv(np.ones(v.shape, dtype=float) if sb is None else sb, bfft, kernel_fft=True)
+#    mom0 = None if sb is None else _cnv(sb, bfft, kernel_fft=True)
 
     # First moment
     mom1 = _cnv(v if sb is None else sb*v, bfft, kernel_fft=True)
@@ -336,7 +337,9 @@ def smear(v, beam, beam_fft=False, sb=None, sig=None, cnvfftw=None):
     # Second moment
     _sig = np.square(v) + np.square(sig)
     mom2 = _cnv(_sig if sb is None else sb*_sig, bfft, kernel_fft=True)
-    mom2 = mom2 / (mom0 + (mom0 == 0.0)) - mom1**2
+    if mom0 is not None:
+        mom2 /= (mom0 + (mom0 == 0.0))
+    mom2 -= mom1**2
     mom2[mom2 < 0] = 0.0
     return mom0, mom1, np.sqrt(mom2)
 


### PR DESCRIPTION
This PR:
 - enables fitting the velocity dispersion with the `AxisymmetricDisk` class
 - changes a couple of aspects of how the corrected velocity dispersions are constructed
 - always forces the calculation of `mom0` in the beam-smearing function using a unity array instead of just ignoring it.

The latter change has a ~1% effect on the results of the beam-smeared velocity, but a greater effect on the beam-smeared velocity dispersion.